### PR TITLE
building: Allow usage of VSVersionInfo again.

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -424,7 +424,8 @@ class EXE(Target):
                                  "", "OPTION"))
 
             if self.versrsrc:
-                if not os.path.isabs(self.versrsrc):
+                if (not isinstance(self.versrsrc, versioninfo.VSVersionInfo)
+                        and not os.path.isabs(self.versrsrc)):
                     # relative version-info path is relative to spec file
                     self.versrsrc = os.path.join(
                         CONF['specpath'], self.versrsrc)


### PR DESCRIPTION
fixes #4381